### PR TITLE
Add filtering by process id, thread id, or process name

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,9 @@ Examples:
   etrace --file trace.etl --stats
   etrace --clr GC --event GC/Start --field PID,TID,Reason[12],Type
   etrace --kernel Process --event Process/Start --where ImageFileName=myapp
+  etrace --kernel Process --event --where ProcessName=myProcessName
+  etrace --kernel Process --event --where Thread/Start ProcessId=4
+  etrace --kernel Process --event Thread/Stop --where ThreadId=10272	
   etrace --clr GC --event GC/Start --duration 60
   etrace --other Microsoft-Windows-Win32k --event QueuePostMessage
   etrace --list CLR,Kernel

--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ Examples:
   etrace --file trace.etl --stats
   etrace --clr GC --event GC/Start --field PID,TID,Reason[12],Type
   etrace --kernel Process --event Process/Start --where ImageFileName=myapp
-  etrace --kernel Process --event --where ProcessName=myProcessName
-  etrace --kernel Process --event --where Thread/Start ProcessId=4
+  etrace --kernel Process --where ProcessName=myProcessName
+  etrace --kernel Process --event Thread/Stop --where ProcessId=4
   etrace --kernel Process --event Thread/Stop --where ThreadId=10272	
   etrace --clr GC --event GC/Start --duration 60
   etrace --other Microsoft-Windows-Win32k --event QueuePostMessage

--- a/etrace/Extensions.cs
+++ b/etrace/Extensions.cs
@@ -9,7 +9,7 @@ namespace etrace
         public static string AsRawString(this TraceEvent e)
         {
             var sb = new StringBuilder();
-            sb.Append($"{e.EventName} [PID={e.ProcessID} TID={e.ThreadID} TIME={e.TimeStamp}]");
+            sb.Append($"{e.EventName} [PNAME={e.ProcessName} PID={e.ProcessID} TID={e.ThreadID} TIME={e.TimeStamp}]");
             for (int i = 0; i < e.PayloadNames.Length; ++i)
             {
                 try

--- a/etrace/Options.cs
+++ b/etrace/Options.cs
@@ -87,8 +87,8 @@ namespace etrace
             help.AddPostOptionsLine("  etrace --file trace.etl --stats");
             help.AddPostOptionsLine("  etrace --clr GC --event GC/Start --field PID,TID,Reason[12],Type");
             help.AddPostOptionsLine("  etrace --kernel Process --event Process/Start --where ImageFileName=myapp");
-            help.AddPostOptionsLine("  etrace --kernel Process --event --where ProcessId=4");
-            help.AddPostOptionsLine("  etrace --kernel Process --event --where ProcessName=myProcessName");
+            help.AddPostOptionsLine("  etrace --kernel Process --where ProcessId=4");
+            help.AddPostOptionsLine("  etrace --kernel Process --where ProcessName=myProcessName");	
             help.AddPostOptionsLine("  etrace --kernel Process --event Thread/Stop --where ThreadId=10272");
             help.AddPostOptionsLine("  etrace --clr GC --event GC/Start --duration 60");
             help.AddPostOptionsLine("  etrace --other Microsoft-Windows-Win32k --event QueuePostMessage");

--- a/etrace/Options.cs
+++ b/etrace/Options.cs
@@ -87,6 +87,9 @@ namespace etrace
             help.AddPostOptionsLine("  etrace --file trace.etl --stats");
             help.AddPostOptionsLine("  etrace --clr GC --event GC/Start --field PID,TID,Reason[12],Type");
             help.AddPostOptionsLine("  etrace --kernel Process --event Process/Start --where ImageFileName=myapp");
+            help.AddPostOptionsLine("  etrace --kernel Process --event --where ProcessId=4");
+            help.AddPostOptionsLine("  etrace --kernel Process --event --where ProcessName=myProcessName");
+            help.AddPostOptionsLine("  etrace --kernel Process --event Thread/Stop --where ThreadId=10272");
             help.AddPostOptionsLine("  etrace --clr GC --event GC/Start --duration 60");
             help.AddPostOptionsLine("  etrace --other Microsoft-Windows-Win32k --event QueuePostMessage");
             help.AddPostOptionsLine("  etrace --list CLR,Kernel");

--- a/etrace/Program.cs
+++ b/etrace/Program.cs
@@ -233,11 +233,11 @@ namespace etrace
                 foreach (var filter in options.ParsedFilters)
                 {
                     Regex valueRegex = filter.Value;
+                    string regexStr = valueRegex.ToString();
 
-                    if (string.Equals(filter.Key, nameof(e.ProcessID), StringComparison.OrdinalIgnoreCase)
-                        && string.Equals(valueRegex.ToString(), e.ProcessID.ToString())
-                        || string.Equals(filter.Key, nameof(e.ThreadID), StringComparison.OrdinalIgnoreCase)
-                        && string.Equals(valueRegex.ToString(), e.ThreadID.ToString()))
+                    if (CheckFilter(filter.Key, nameof(e.ProcessID), regexStr, e.ProcessID.ToString())
+                       || CheckFilter(filter.Key, nameof(e.ThreadID), regexStr, e.ThreadID.ToString())
+                       || CheckFilter(filter.Key, nameof(e.ProcessName), regexStr, e.ProcessName))
                     {
                         TakeEvent(e);
                         break;
@@ -260,6 +260,12 @@ namespace etrace
             {
                 TakeEvent(e);
             }
+        }
+
+        private static bool CheckFilter(string fiterKey, string eventKey, string filterValue, string eventValue)
+        {
+            return string.Equals(fiterKey, eventKey, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(filterValue, eventValue);
         }
 
         private static void TakeEvent(TraceEvent e, string description = null)


### PR DESCRIPTION
Added support for event filtering using --where verb, example:
 
--kernel Process --event --where ProcessName="<your-process-name>" 
 --kernel Process --event --where ThreadId="<your-thread-Id>"
 --kernel Process --event --where ProcessId="<your-process-Id>"
 
However, the filters doesn't depend one on another, for exmple:
 --kernel Process --event --where ProcessId="<your-process-Id>" ThreadId="<threadId>"
will generate the same output as 
 --kernel Process --event --where ProcessId="<your-process-Id>"
* Because it will match ProcessId is both filters.

Does this functionality required?

____

Updated: resolves #1.
