### PR TITLE
Issue #7 : More complex filters 

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,9 @@ Examples:
   etrace --file trace.etl --stats
   etrace --clr GC --event GC/Start --field PID,TID,Reason[12],Type
   etrace --kernel Process --event Process/Start --where ImageFileName=myapp
+  etrace --kernel Process --event --where ProcessName=myProcessName
+  etrace --kernel Process --event --where Thread/Start ProcessId=4
+  etrace --kernel Process --event Thread/Stop --where ThreadId=10272	
   etrace --clr GC --event GC/Start --duration 60
   etrace --other Microsoft-Windows-Win32k --event QueuePostMessage
   etrace --list CLR,Kernel

--- a/README.md
+++ b/README.md
@@ -213,7 +213,9 @@ Examples:
   etrace --kernel Process --where ProcessName=myProcessName
   etrace --kernel Process --event Thread/Stop --where ProcessId=4
   etrace --kernel Process --event Thread/Stop --where ThreadId=10272	
+  etrace --kernel Process --event --where "ThreadId > 1 && ... && ProcessName=git-lfs"
   etrace --clr GC --event GC/Start --duration 60
   etrace --other Microsoft-Windows-Win32k --event QueuePostMessage
+  
   etrace --list CLR,Kernel
 ```

--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ Examples:
   etrace --file trace.etl --stats
   etrace --clr GC --event GC/Start --field PID,TID,Reason[12],Type
   etrace --kernel Process --event Process/Start --where ImageFileName=myapp
-  etrace --kernel Process --event --where ProcessName=myProcessName
-  etrace --kernel Process --event --where Thread/Start ProcessId=4
+  etrace --kernel Process --where ProcessName=myProcessName
+  etrace --kernel Process --event Thread/Stop --where ProcessId=4
   etrace --kernel Process --event Thread/Stop --where ThreadId=10272	
   etrace --clr GC --event GC/Start --duration 60
   etrace --other Microsoft-Windows-Win32k --event QueuePostMessage

--- a/README.md
+++ b/README.md
@@ -213,9 +213,8 @@ Examples:
   etrace --kernel Process --where ProcessName=myProcessName
   etrace --kernel Process --event Thread/Stop --where ProcessId=4
   etrace --kernel Process --event Thread/Stop --where ThreadId=10272	
-  etrace --kernel Process --event --where "ThreadId > 1 && ... && ProcessName=git-lfs"
+  etrace --kernel Process --event --where "ThreadId > 1 && ProcessName=git-lfs"
   etrace --clr GC --event GC/Start --duration 60
   etrace --other Microsoft-Windows-Win32k --event QueuePostMessage
-  
   etrace --list CLR,Kernel
 ```

--- a/etrace/Extensions.cs
+++ b/etrace/Extensions.cs
@@ -9,7 +9,7 @@ namespace etrace
         public static string AsRawString(this TraceEvent e)
         {
             var sb = new StringBuilder();
-            sb.Append($"{e.EventName} [PID={e.ProcessID} TID={e.ThreadID} TIME={e.TimeStamp}]");
+            sb.Append($"{e.EventName} [PNAME={e.ProcessName} PID={e.ProcessID} TID={e.ThreadID} TIME={e.TimeStamp}]");
             for (int i = 0; i < e.PayloadNames.Length; ++i)
             {
                 try

--- a/etrace/Options.cs
+++ b/etrace/Options.cs
@@ -284,7 +284,7 @@ namespace etrace
             }
 
             /// <summary>
-            ///  Checks by OperatorChar if filter matches event 
+            ///  Checks if given key ad value match filter ( by OperatorChar )
             /// </summary>
             /// <returns>true if matches the event</returns>
             private bool IsMatch(string key, string value)

--- a/etrace/Options.cs
+++ b/etrace/Options.cs
@@ -87,8 +87,8 @@ namespace etrace
             help.AddPostOptionsLine("  etrace --file trace.etl --stats");
             help.AddPostOptionsLine("  etrace --clr GC --event GC/Start --field PID,TID,Reason[12],Type");
             help.AddPostOptionsLine("  etrace --kernel Process --event Process/Start --where ImageFileName=myapp");
-            help.AddPostOptionsLine("  etrace --kernel Process --event --where ProcessId=4");
-            help.AddPostOptionsLine("  etrace --kernel Process --event --where ProcessName=myProcessName");
+            help.AddPostOptionsLine("  etrace --kernel Process --where ProcessId=4");
+            help.AddPostOptionsLine("  etrace --kernel Process --where ProcessName=myProcessName");	
             help.AddPostOptionsLine("  etrace --kernel Process --event Thread/Stop --where ThreadId=10272");
             help.AddPostOptionsLine("  etrace --clr GC --event GC/Start --duration 60");
             help.AddPostOptionsLine("  etrace --other Microsoft-Windows-Win32k --event QueuePostMessage");

--- a/etrace/Options.cs
+++ b/etrace/Options.cs
@@ -9,14 +9,14 @@ using Microsoft.Diagnostics.Tracing;
 namespace etrace
 {
     [Flags]
-    enum ListFlags : int
+	enum ListFlags: int
     {
-        None = 0x0,
-        Kernel = 0x1,
-        CLR = 0x2,
+        None       = 0x0,
+        Kernel     = 0x1,
+        CLR        = 0x2,
         Registered = 0x4,
-        Published = 0x8,
-        All = Kernel | CLR | Registered | Published
+        Published  = 0x8,
+        All        = Kernel | CLR | Registered | Published
     }
 
     class Options
@@ -142,14 +142,16 @@ namespace etrace
             }
             else
             {
-                if (filter.Contains(Filter.GREATER_EQUAL_SIGN))
-                    result = ParseAnyOfFilter(filter, Filter.GREATER_EQUAL_SIGN);
-                if (filter.Contains(Filter.LESS_EQUAL_SIGN))
-                    result = ParseAnyOfFilter(filter, Filter.LESS_EQUAL_SIGN);
+                if (filter.Contains(Filter.GREATER_OR_EQUAL_SIGN))
+                    result = ParseAnyOfFilter(filter, Filter.GREATER_OR_EQUAL_SIGN);
+                if (filter.Contains(Filter.LESS_OR_EQUAL_SIGN))
+                    result = ParseAnyOfFilter(filter, Filter.LESS_OR_EQUAL_SIGN);
                 if (filter.Contains(Filter.GREATER_SIGN))
                     result = ParseAnyOfFilter(filter, Filter.GREATER_SIGN);
                 else if (filter.Contains(Filter.LESS_SIGN))
                     result = ParseAnyOfFilter(filter, Filter.LESS_SIGN);
+                else if (filter.Contains(Filter.NOT_EQUAL_SIGN))
+                    result = ParseAnyOfFilter(filter, Filter.NOT_EQUAL_SIGN);
                 else
                     result = ParseAnyOfFilter(filter, Filter.EQUAL_SIGN);
             }
@@ -237,13 +239,14 @@ namespace etrace
         {
             #region Const Signs
 
-            internal const string GREATER_EQUAL_SIGN = ">=";
+            internal const string GREATER_OR_EQUAL_SIGN = ">=";
             internal const string GREATER_SIGN = ">";
-            internal const string LESS_EQUAL_SIGN = "<=";
+            internal const string LESS_OR_EQUAL_SIGN = "<=";
             internal const string LESS_SIGN = "<";
             internal const string EQUAL_SIGN = "=";
+            internal const string NOT_EQUAL_SIGN = "!=";
             internal const string DOUBLE_EQUAL_SIGN = "==";
-
+            
             #endregion
 
             protected Filter()
@@ -298,11 +301,14 @@ namespace etrace
                         case LESS_SIGN:
                             result = int.Parse(this.RawValue) > int.Parse(value);
                             break;
-                        case LESS_EQUAL_SIGN:
+                        case LESS_OR_EQUAL_SIGN:
                             result = int.Parse(this.RawValue) >= int.Parse(value);
                             break;
-                        case GREATER_EQUAL_SIGN:
+                        case GREATER_OR_EQUAL_SIGN:
                             result = int.Parse(this.RawValue) <= int.Parse(value);
+                            break;
+                        case NOT_EQUAL_SIGN:
+                            result = int.Parse(this.RawValue) != int.Parse(value);
                             break;
                         case EQUAL_SIGN:
                         case DOUBLE_EQUAL_SIGN:

--- a/etrace/Options.cs
+++ b/etrace/Options.cs
@@ -2,6 +2,7 @@
 using CommandLine.Text;
 using Microsoft.Diagnostics.Tracing.Parsers;
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Microsoft.Diagnostics.Tracing;
@@ -213,25 +214,9 @@ namespace etrace
 
             public List<Filter> SubFilters { get; set; }
 
-            /// <summary>
-            ///  Checks whether all sub-filters matches the event
-            /// </summary>
-            /// <param name="e">event</param>
-            /// <returns>true if all of sub-filters match the event</returns>
             internal override bool IsMatch(TraceEvent e)
             {
-                bool result = true;
-
-                foreach (var subFilter in SubFilters)
-                {
-                    if (!subFilter.IsMatch(e))
-                    {
-                        result = false;
-                        break;
-                    }
-                }
-
-                return result;
+                return SubFilters.All(s => s.IsMatch(e));
             }
         }
 
@@ -321,10 +306,6 @@ namespace etrace
                 return result;
             }
 
-            /// <summary>
-            /// Checks if filter matches event payload - by filter key
-            /// </summary>
-            /// <returns>true if filter matches the event</returns>
             private bool IsPayloadMatch(TraceEvent e)
             {
                 bool result = false;
@@ -356,4 +337,3 @@ namespace etrace
         }
     }
 }
-

--- a/etrace/Options.cs
+++ b/etrace/Options.cs
@@ -87,6 +87,9 @@ namespace etrace
             help.AddPostOptionsLine("  etrace --file trace.etl --stats");
             help.AddPostOptionsLine("  etrace --clr GC --event GC/Start --field PID,TID,Reason[12],Type");
             help.AddPostOptionsLine("  etrace --kernel Process --event Process/Start --where ImageFileName=myapp");
+            help.AddPostOptionsLine("  etrace --kernel Process --event --where ProcessId=4");
+            help.AddPostOptionsLine("  etrace --kernel Process --event --where ProcessName=myProcessName");
+            help.AddPostOptionsLine("  etrace --kernel Process --event Thread/Stop --where ThreadId=10272");
             help.AddPostOptionsLine("  etrace --clr GC --event GC/Start --duration 60");
             help.AddPostOptionsLine("  etrace --other Microsoft-Windows-Win32k --event QueuePostMessage");
             help.AddPostOptionsLine("  etrace --list CLR,Kernel");

--- a/etrace/Options.cs
+++ b/etrace/Options.cs
@@ -10,7 +10,7 @@ using Microsoft.Diagnostics.Tracing;
 namespace etrace
 {
     [Flags]
-	enum ListFlags: int
+    enum ListFlags: int
     {
         None       = 0x0,
         Kernel     = 0x1,

--- a/etrace/Program.cs
+++ b/etrace/Program.cs
@@ -232,27 +232,10 @@ namespace etrace
             {
                 foreach (var filter in options.ParsedFilters)
                 {
-                    Regex valueRegex = filter.Value;
-                    string regexStr = valueRegex.ToString();
-
-                    if (CheckFilter(filter.Key, nameof(e.ProcessID), regexStr, e.ProcessID.ToString())
-                       || CheckFilter(filter.Key, nameof(e.ThreadID), regexStr, e.ThreadID.ToString())
-                       || CheckFilter(filter.Key, nameof(e.ProcessName), regexStr, e.ProcessName))
+                    if (filter.IsMatch(e))
                     {
                         TakeEvent(e);
                         break;
-                    }
-
-                    string payloadName = filter.Key;
-                    object payloadValue = e.PayloadByName(payloadName);
-
-                    if (payloadValue != null)
-                    {
-                        if (valueRegex.IsMatch(payloadValue.ToString()))
-                        {
-                            TakeEvent(e);
-                            break;
-                        }
                     }
                 }
             }
@@ -260,6 +243,11 @@ namespace etrace
             {
                 TakeEvent(e);
             }
+        }
+
+        private static bool CheckFilter(string key, string v1, object rawValue, string v2)
+        {
+            throw new NotImplementedException();
         }
 
         private static bool CheckFilter(string fiterKey, string eventKey, string filterValue, string eventValue)

--- a/etrace/Program.cs
+++ b/etrace/Program.cs
@@ -245,17 +245,6 @@ namespace etrace
             }
         }
 
-        private static bool CheckFilter(string key, string v1, object rawValue, string v2)
-        {
-            throw new NotImplementedException();
-        }
-
-        private static bool CheckFilter(string fiterKey, string eventKey, string filterValue, string eventValue)
-        {
-            return string.Equals(fiterKey, eventKey, StringComparison.OrdinalIgnoreCase)
-                && string.Equals(filterValue, eventValue);
-        }
-
         private static void TakeEvent(TraceEvent e, string description = null)
         {
             if (description != null)

--- a/etrace/Program.cs
+++ b/etrace/Program.cs
@@ -5,7 +5,6 @@ using Microsoft.Diagnostics.Tracing.Session;
 using System;
 using System.Diagnostics;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace etrace

--- a/etrace/Program.cs
+++ b/etrace/Program.cs
@@ -232,42 +232,11 @@ namespace etrace
                 foreach (var filter in options.ParsedFilters)
                 {
                     if (filter.IsMatch(e))
-                    string regexStr = valueRegex.ToString();
-
-                    if (CheckFilter(filter.Key, nameof(e.ProcessID), regexStr, e.ProcessID.ToString())
-                       || CheckFilter(filter.Key, nameof(e.ThreadID), regexStr, e.ThreadID.ToString())
-                       || CheckFilter(filter.Key, nameof(e.ProcessName), regexStr, e.ProcessName))
                     {
                         TakeEvent(e);
                         break;
                     }
-                    string payloadName = filter.Key;
-                    if (payloadValue != null)
-                    {
-                        {
-                        TakeEvent(e);
-                            break;
-                        }
-                    }
                 }
-            }
-            else
-            {
-                TakeEvent(e);
-            }
-        }
-
-        private static bool CheckFilter(string fiterKey, string eventKey, string filterValue, string eventValue)
-        {
-            return string.Equals(fiterKey, eventKey, StringComparison.OrdinalIgnoreCase)
-                && string.Equals(filterValue, eventValue);
-        }
-
-        private static void TakeEvent(TraceEvent e, string description = null)
-        {
-            if (description != null)
-            {
-                eventProcessor.TakeEvent(e, description);
             }
             else
             {

--- a/etrace/Program.cs
+++ b/etrace/Program.cs
@@ -240,6 +240,9 @@ namespace etrace
             }
             else
             {
+
+            }
+            {
                 TakeEvent(e);
             }
         }

--- a/etrace/Program.cs
+++ b/etrace/Program.cs
@@ -233,11 +233,11 @@ namespace etrace
                 foreach (var filter in options.ParsedFilters)
                 {
                     Regex valueRegex = filter.Value;
+                    string regexStr = valueRegex.ToString();
 
-                    if (string.Equals(filter.Key, nameof(e.ProcessID), StringComparison.OrdinalIgnoreCase)
-                        && string.Equals(valueRegex.ToString(), e.ProcessID.ToString())
-                        || string.Equals(filter.Key, nameof(e.ThreadID), StringComparison.OrdinalIgnoreCase)
-                        && string.Equals(valueRegex.ToString(), e.ThreadID.ToString()))
+                    if (CheckFilter(filter.Key, nameof(e.ProcessID), regexStr, e.ProcessID.ToString())
+                       || CheckFilter(filter.Key, nameof(e.ThreadID), regexStr, e.ThreadID.ToString())
+                       || CheckFilter(filter.Key, nameof(e.ProcessName), regexStr, e.ProcessName))
                     {
                         TakeEvent(e);
                         break;
@@ -260,6 +260,12 @@ namespace etrace
             {
                 TakeEvent(e);
             }
+        }
+
+        private static bool CheckFilter(string fiterKey, string eventKey, string filterValue, string eventValue)
+        {
+            return string.Equals(fiterKey, eventKey, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(filterValue, eventValue);
         }
 
         private static void TakeEvent(TraceEvent e, string description = null)


### PR DESCRIPTION
1. Added support for unlimited All-of filters.
2. Added support for ">", "<", ">=", "<=", "!="

example:
`
etrace --kernel Proces --where "ThreadId<20000 && ProcessName=git-lfs && ParentProcessID=19496"
etrace --kernel Process --where "ThreadId>=0 && ThreadId<99 && ProcessId!=2 && StackBase>89"
etrace --kernel Process --where "ThreadId>0"
 #`

For some reason, when using the filter without quotes - 
`etrace --kernel Process --where ThreadId>0`
Parser.ParseArguments(args, options) ->  won't parse ">0" string
`options.Filters =     [0]: "ThreadId"`